### PR TITLE
updating nanopb version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -27,7 +27,7 @@ let package = Package(
     .library(name: "ARCoreSemantics", targets: ["Semantics"]),
   ],
   dependencies: [
-    .package(url: "https://github.com/firebase/nanopb.git", "2.30909.0"..<"2.30911.0"),
+    .package(url: "https://github.com/firebase/nanopb.git", "2.30910.0" ..< "2.30911.0"),
     .package(
       url: "https://github.com/google/GoogleDataTransport.git", .upToNextMajor(from: "9.2.0")),
     .package(url: "https://github.com/google/gtm-session-fetcher.git", "2.1.0"..<"4.0.0"),


### PR DESCRIPTION
Updated nanopb version in package swift. This should fix errors with CocoaPods dependencies, per guidance from https://github.com/firebase/firebase-ios-sdk/issues/13741.